### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <url>https://github.com/wso2-extensions/identity-outbound-provisioning-salesforce.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-outbound-provisioning-salesforce.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-outbound-provisioning-salesforce.git</connection>
-        <tag>v5.2.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
 
@@ -212,8 +212,8 @@
 
     <properties>
         <!--Carbon framework version-->
-        <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
-        <carbon.identity.framework.version>5.5.0</carbon.identity.framework.version>
+        <carbon.identity.framework.import.version.range>[6.0.0, 7.0.0)</carbon.identity.framework.import.version.range>
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
 
         <identity.outbound.provisioning.salesforce.export.version>${project.version}</identity.outbound.provisioning.salesforce.export.version>
 


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16