### PR TITLE
Add client credential grant support to salesforce

### DIFF
--- a/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceConnectorConstants.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceConnectorConstants.java
@@ -30,6 +30,7 @@ public class SalesforceConnectorConstants {
     public static final String CLIENT_SECRET = "client_secret";
     public static final String GRANT_TYPE = "grant_type";
     public static final String GRANT_TYPE_PASSWORD = "password";
+    public static final String GRANT_TYPE_CLIENT_CREDENTIAL = "client_credentials";
     public static final String USERNAME = "username";
     public static final String USERNAME_ATTRIBUTE = "Username";
     public static final String PASSWORD = "password";

--- a/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnector.java
@@ -399,12 +399,8 @@ public class SalesforceProvisioningConnector extends AbstractOutboundProvisionin
                     configHolder.getValue(SalesforceConnectorConstants.PropertyConfig.CLIENT_ID)));
             params.add(new BasicNameValuePair(SalesforceConnectorConstants.CLIENT_SECRET,
                     configHolder.getValue(SalesforceConnectorConstants.PropertyConfig.CLIENT_SECRET)));
-            params.add(new BasicNameValuePair(SalesforceConnectorConstants.PASSWORD,
-                    configHolder.getValue(SalesforceConnectorConstants.PropertyConfig.PASSWORD)));
             params.add(new BasicNameValuePair(SalesforceConnectorConstants.GRANT_TYPE,
-                    SalesforceConnectorConstants.GRANT_TYPE_PASSWORD));
-            params.add(new BasicNameValuePair(SalesforceConnectorConstants.USERNAME,
-                    configHolder.getValue(SalesforceConnectorConstants.PropertyConfig.USERNAME)));
+                    SalesforceConnectorConstants.GRANT_TYPE_CLIENT_CREDENTIAL));
 
             post.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
 

--- a/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnectorFactory.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnectorFactory.java
@@ -91,31 +91,13 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
         clientSecret.setConfidential(true);
         configProperties.add(clientSecret);
 
-        Property username = new Property();
-        username.setName(SalesforceConnectorConstants.PropertyConfig.USERNAME);
-        username.setDisplayName("Username");
-        username.setRequired(true);
-        username.setType("string");
-        username.setDisplayOrder(5);
-        configProperties.add(username);
-
-        Property password = new Property();
-        password.setName(SalesforceConnectorConstants.PropertyConfig.PASSWORD);
-        password.setDisplayName("Password");
-        password.setRequired(true);
-        password.setDescription("Enable User password provisioning to a Salesforce domain");
-        password.setType("boolean");
-        password.setDefaultValue("true");
-        password.setDisplayOrder(6);
-        configProperties.add(password);
-
         Property tokenEp = new Property();
         tokenEp.setName(SalesforceConnectorConstants.PropertyConfig.OAUTH2_TOKEN_ENDPOINT);
         tokenEp.setDisplayName("OAuth2 Token Endpoint");
         tokenEp.setRequired(true);
         tokenEp.setType("string");
         tokenEp.setDefaultValue("https://login.salesforce.com/services/oauth2/token");
-        tokenEp.setDisplayOrder(7);
+        tokenEp.setDisplayOrder(5);
         configProperties.add(tokenEp);
 
         Property provPattern = new Property();
@@ -126,7 +108,7 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
                 "attributes UD (User Domain), UN (Username), TD (Tenant Domain) and IDP (Identity Provider) can be " +
                 "used to construct a valid pattern. Ex: {UD, UN, TD, IDP}");
         provPattern.setType("string");
-        provPattern.setDisplayOrder(8);
+        provPattern.setDisplayOrder(6);
         configProperties.add(provPattern);
 
         Property provSeperator = new Property();
@@ -138,7 +120,7 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
                 "Separator:_, Google Domain : testmail.com then the privisioining email is testUser_testTenant" +
                 ".com@testmail.com");
         provSeperator.setType("string");
-        provSeperator.setDisplayOrder(9);
+        provSeperator.setDisplayOrder(7);
         configProperties.add(provSeperator);
 
         Property provDomain = new Property();
@@ -146,7 +128,7 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
         provDomain.setDisplayName("Provisioning Domain");
         provDomain.setRequired(false);
         provDomain.setType("string");
-        provDomain.setDisplayOrder(10);
+        provDomain.setDisplayOrder(8);
         configProperties.add(provDomain);
 
         return configProperties;


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/19577

With this PR, we are removing password grant cause [OAuth 2.0 Username-Password Flow Blocked by Default in New Orgs](https://help.salesforce.com/s/articleView?id=release-notes.rn_security_username-password_flow_blocked_by_default.htm&release=244&type=5).

We are switching to Client Credential grant. We need to improve doc also and the prod token endpoint (**https://login.salesforce.com/services/oauth2/token**) is not support for client credential grant so the developer has to use their our domain name.(**https://`<domain-name>`.my.salesforce.com/services/oauth2/token**)

Outbound Provisiong ConnectorUI
<img width="1728" alt="Connector UI" src="https://github.com/wso2-extensions/identity-outbound-provisioning-salesforce/assets/25488962/e6d04965-e269-4200-8677-9eb3f0a0e656">


