### PR TITLE
Support cc for salesforce

### DIFF
--- a/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceConnectorConstants.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceConnectorConstants.java
@@ -54,6 +54,11 @@ public class SalesforceConnectorConstants {
     public static final String SALESFORCE_ENDPOINT_QUERY = "/query";
     public static final String SALESFORCE_OLD_USERNAME_PREFIX = "old";
 
+    // Constants related to hostname verification
+    public static final String DEFAULT_AND_LOCALHOST = "DefaultAndLocalhost";
+    public static final String ALLOW_ALL = "AllowAll";
+    public static final String HOST_NAME_VERIFIER = "httpclient.hostnameVerifier";
+
     public class PropertyConfig {
 
         public static final String IDP_NAME = "Identity.Provisioning.Connector.Salesforce.IdP.Name";
@@ -73,6 +78,7 @@ public class SalesforceConnectorConstants {
         public static final String GRANT_TYPE = "grant_type";
         public static final String USERNAME = "sf-username";
         public static final String PASSWORD = "sf-password";
+        public static final String USE_PASSWORD_GRANT = "sf-usePasswordGrant";
         public static final String OAUTH2_TOKEN_ENDPOINT = "sf-token-endpoint";
 
         public static final String PROVISIONING_PATTERN_KEY = "sf-prov-pattern";

--- a/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceConnectorConstants.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceConnectorConstants.java
@@ -54,11 +54,6 @@ public class SalesforceConnectorConstants {
     public static final String SALESFORCE_ENDPOINT_QUERY = "/query";
     public static final String SALESFORCE_OLD_USERNAME_PREFIX = "old";
 
-    // Constants related to hostname verification
-    public static final String DEFAULT_AND_LOCALHOST = "DefaultAndLocalhost";
-    public static final String ALLOW_ALL = "AllowAll";
-    public static final String HOST_NAME_VERIFIER = "httpclient.hostnameVerifier";
-
     public class PropertyConfig {
 
         public static final String IDP_NAME = "Identity.Provisioning.Connector.Salesforce.IdP.Name";

--- a/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceConnectorConstants.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceConnectorConstants.java
@@ -30,6 +30,7 @@ public class SalesforceConnectorConstants {
     public static final String CLIENT_SECRET = "client_secret";
     public static final String GRANT_TYPE = "grant_type";
     public static final String GRANT_TYPE_PASSWORD = "password";
+    public static final String GRANT_TYPE_CLIENT_CREDENTIAL = "client_credentials";
     public static final String USERNAME = "username";
     public static final String USERNAME_ATTRIBUTE = "Username";
     public static final String PASSWORD = "password";

--- a/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnector.java
@@ -399,12 +399,8 @@ public class SalesforceProvisioningConnector extends AbstractOutboundProvisionin
                     configHolder.getValue(SalesforceConnectorConstants.PropertyConfig.CLIENT_ID)));
             params.add(new BasicNameValuePair(SalesforceConnectorConstants.CLIENT_SECRET,
                     configHolder.getValue(SalesforceConnectorConstants.PropertyConfig.CLIENT_SECRET)));
-            params.add(new BasicNameValuePair(SalesforceConnectorConstants.PASSWORD,
-                    configHolder.getValue(SalesforceConnectorConstants.PropertyConfig.PASSWORD)));
             params.add(new BasicNameValuePair(SalesforceConnectorConstants.GRANT_TYPE,
-                    SalesforceConnectorConstants.GRANT_TYPE_PASSWORD));
-            params.add(new BasicNameValuePair(SalesforceConnectorConstants.USERNAME,
-                    configHolder.getValue(SalesforceConnectorConstants.PropertyConfig.USERNAME)));
+                    SalesforceConnectorConstants.GRANT_TYPE_CLIENT_CREDENTIAL));
 
             post.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
 

--- a/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnector.java
@@ -399,8 +399,18 @@ public class SalesforceProvisioningConnector extends AbstractOutboundProvisionin
                     configHolder.getValue(SalesforceConnectorConstants.PropertyConfig.CLIENT_ID)));
             params.add(new BasicNameValuePair(SalesforceConnectorConstants.CLIENT_SECRET,
                     configHolder.getValue(SalesforceConnectorConstants.PropertyConfig.CLIENT_SECRET)));
-            params.add(new BasicNameValuePair(SalesforceConnectorConstants.GRANT_TYPE,
-                    SalesforceConnectorConstants.GRANT_TYPE_CLIENT_CREDENTIAL));
+            if (Boolean.parseBoolean(configHolder.getValue(
+                    SalesforceConnectorConstants.PropertyConfig.USE_PASSWORD_GRANT))){
+                params.add(new BasicNameValuePair(SalesforceConnectorConstants.PASSWORD,
+                        configHolder.getValue(SalesforceConnectorConstants.PropertyConfig.PASSWORD)));
+                params.add(new BasicNameValuePair(SalesforceConnectorConstants.GRANT_TYPE,
+                        SalesforceConnectorConstants.GRANT_TYPE_PASSWORD));
+                params.add(new BasicNameValuePair(SalesforceConnectorConstants.USERNAME,
+                        configHolder.getValue(SalesforceConnectorConstants.PropertyConfig.USERNAME)));
+            } else {
+                params.add(new BasicNameValuePair(SalesforceConnectorConstants.GRANT_TYPE,
+                        SalesforceConnectorConstants.GRANT_TYPE_CLIENT_CREDENTIAL));
+            }
 
             post.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
 

--- a/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnectorFactory.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnectorFactory.java
@@ -91,13 +91,38 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
         clientSecret.setConfidential(true);
         configProperties.add(clientSecret);
 
+        Property username = new Property();
+        username.setName(SalesforceConnectorConstants.PropertyConfig.USERNAME);
+        username.setDisplayName("Username");
+        username.setRequired(false);
+        username.setType("string");
+        username.setDisplayOrder(5);
+        configProperties.add(username);
+
+        Property password = new Property();
+        password.setName(SalesforceConnectorConstants.PropertyConfig.PASSWORD);
+        password.setDisplayName("Password");
+        password.setRequired(false);
+        password.setType("string");
+        password.setDisplayOrder(6);
+        password.setConfidential(true);
+        configProperties.add(password);
+
+        Property grantType = new Property();
+        grantType.setName(SalesforceConnectorConstants.PropertyConfig.USE_PASSWORD_GRANT);
+        grantType.setDisplayName("Use Username-Password grant to get access token");
+        grantType.setType("boolean");
+        grantType.setDefaultValue("true");
+        grantType.setDisplayOrder(7);
+        configProperties.add(grantType);
+
         Property tokenEp = new Property();
         tokenEp.setName(SalesforceConnectorConstants.PropertyConfig.OAUTH2_TOKEN_ENDPOINT);
         tokenEp.setDisplayName("OAuth2 Token Endpoint");
         tokenEp.setRequired(true);
         tokenEp.setType("string");
         tokenEp.setDefaultValue("https://login.salesforce.com/services/oauth2/token");
-        tokenEp.setDisplayOrder(5);
+        tokenEp.setDisplayOrder(8);
         configProperties.add(tokenEp);
 
         Property provPattern = new Property();
@@ -108,7 +133,7 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
                 "attributes UD (User Domain), UN (Username), TD (Tenant Domain) and IDP (Identity Provider) can be " +
                 "used to construct a valid pattern. Ex: {UD, UN, TD, IDP}");
         provPattern.setType("string");
-        provPattern.setDisplayOrder(6);
+        provPattern.setDisplayOrder(9);
         configProperties.add(provPattern);
 
         Property provSeperator = new Property();
@@ -120,7 +145,7 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
                 "Separator:_, Google Domain : testmail.com then the privisioining email is testUser_testTenant" +
                 ".com@testmail.com");
         provSeperator.setType("string");
-        provSeperator.setDisplayOrder(7);
+        provSeperator.setDisplayOrder(10);
         configProperties.add(provSeperator);
 
         Property provDomain = new Property();
@@ -128,7 +153,7 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
         provDomain.setDisplayName("Provisioning Domain");
         provDomain.setRequired(false);
         provDomain.setType("string");
-        provDomain.setDisplayOrder(8);
+        provDomain.setDisplayOrder(11);
         configProperties.add(provDomain);
 
         return configProperties;

--- a/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnectorFactory.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnectorFactory.java
@@ -91,31 +91,13 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
         clientSecret.setConfidential(true);
         configProperties.add(clientSecret);
 
-        Property username = new Property();
-        username.setName(SalesforceConnectorConstants.PropertyConfig.USERNAME);
-        username.setDisplayName("Username");
-        username.setRequired(true);
-        username.setType("string");
-        username.setDisplayOrder(5);
-        configProperties.add(username);
-
-        Property password = new Property();
-        password.setName(SalesforceConnectorConstants.PropertyConfig.PASSWORD);
-        password.setDisplayName("Password");
-        password.setRequired(true);
-        password.setDescription("Enable User password provisioning to a Salesforce domain");
-        password.setType("boolean");
-        password.setDefaultValue("true");
-        password.setDisplayOrder(6);
-        configProperties.add(password);
-
         Property tokenEp = new Property();
         tokenEp.setName(SalesforceConnectorConstants.PropertyConfig.OAUTH2_TOKEN_ENDPOINT);
         tokenEp.setDisplayName("OAuth2 Token Endpoint");
         tokenEp.setRequired(true);
         tokenEp.setType("string");
         tokenEp.setDefaultValue("https://login.salesforce.com/services/oauth2/token");
-        tokenEp.setDisplayOrder(7);
+        tokenEp.setDisplayOrder(5);
         configProperties.add(tokenEp);
 
         Property provPattern = new Property();
@@ -126,7 +108,7 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
                 "attributes UD (User Domain), UN (Username), TD (Tenant Domain) and IDP (Identity Provider) can be " +
                 "used to construct a valid pattern. Ex: {UD, UN, TD, IDP}");
         provPattern.setType("string");
-        provPattern.setDisplayOrder(8);
+        provPattern.setDisplayOrder(6);
         configProperties.add(provPattern);
 
         Property provSeperator = new Property();
@@ -138,7 +120,7 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
                 "Separator:_, Google Domain : testmail.com then the privisioining email is testUser_testTenant" +
                 ".com@testmail.com");
         provSeperator.setType("string");
-        provSeperator.setDisplayOrder(9);
+        provSeperator.setDisplayOrder(7);
         configProperties.add(provSeperator);
 
         Property provDomain = new Property();
@@ -146,7 +128,7 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
         provDomain.setDisplayName("Provisioning Domain");
         provDomain.setRequired(false);
         provDomain.setType("string");
-        provDomain.setDisplayOrder(10);
+        provDomain.setDisplayOrder(8);
         configProperties.add(provDomain);
 
         return configProperties;

--- a/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnectorFactory.java
+++ b/components/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnectorFactory.java
@@ -91,12 +91,20 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
         clientSecret.setConfidential(true);
         configProperties.add(clientSecret);
 
+        Property grantType = new Property();
+        grantType.setName(SalesforceConnectorConstants.PropertyConfig.USE_PASSWORD_GRANT);
+        grantType.setDisplayName("Use OAuth Username-Password Flow to get access token");
+        grantType.setType("boolean");
+        grantType.setDefaultValue("true");
+        grantType.setDisplayOrder(5);
+        configProperties.add(grantType);
+
         Property username = new Property();
         username.setName(SalesforceConnectorConstants.PropertyConfig.USERNAME);
         username.setDisplayName("Username");
         username.setRequired(false);
         username.setType("string");
-        username.setDisplayOrder(5);
+        username.setDisplayOrder(6);
         configProperties.add(username);
 
         Property password = new Property();
@@ -104,17 +112,9 @@ public class SalesforceProvisioningConnectorFactory extends AbstractProvisioning
         password.setDisplayName("Password");
         password.setRequired(false);
         password.setType("string");
-        password.setDisplayOrder(6);
+        password.setDisplayOrder(7);
         password.setConfidential(true);
         configProperties.add(password);
-
-        Property grantType = new Property();
-        grantType.setName(SalesforceConnectorConstants.PropertyConfig.USE_PASSWORD_GRANT);
-        grantType.setDisplayName("Use Username-Password grant to get access token");
-        grantType.setType("boolean");
-        grantType.setDefaultValue("true");
-        grantType.setDisplayOrder(7);
-        configProperties.add(grantType);
 
         Property tokenEp = new Property();
         tokenEp.setName(SalesforceConnectorConstants.PropertyConfig.OAUTH2_TOKEN_ENDPOINT);


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/19577

With this PR, we are giving choice to use password grant and client credential grant  cause  password grant  [OAuth 2.0 Username-Password Flow Blocked by Default in New Orgs](https://help.salesforce.com/s/articleView?id=release-notes.rn_security_username-password_flow_blocked_by_default.htm&release=244&type=5).

When we are switching to Client Credential grant. We need to improve doc also and  token endpoint (**https://login.salesforce.com/services/oauth2/token**) is not support for client credential grant so the developer has to use their our domain name.(**https://`<domain-name>`.my.salesforce.com/services/oauth2/token**)

Along with that we need to enable client credential flow in the OAuth setting and assign a user for client credential flow.

UI
<img width="1728" alt="Screenshot 2024-02-19 at 12 11 29" src="https://github.com/wso2-extensions/identity-outbound-provisioning-salesforce/assets/25488962/89b64cc2-b20b-46fd-b63f-6bdf5c0e3987">



